### PR TITLE
use `.getRaw()` instead of .raw for the getting the pressed key

### DIFF
--- a/src/Kaleidoscope/LangPack-European.cpp
+++ b/src/Kaleidoscope/LangPack-European.cpp
@@ -48,7 +48,7 @@ EventHandlerResult European::onKeyswitchEvent(Key &mapped_key, KeyAddr key_addr,
   accent.setFlags(KEY_FLAGS);
   accent.setKeyCode(Key_Quote.getKeyCode());
 
-  switch (mapped_key.raw) {
+  switch (mapped_key.getRaw()) {
   case INTL_AACUTE:
     kc = Key_A.keyCode;
     break;


### PR DESCRIPTION
This change was needed in order for it to compile with the latest
`master` of Kaleidoscope.

Not sure if you want this formatted a different way in commit message or
else, but just let me know - happy to help! Thanks for an awesome
project, made my ErgoDox much nicer to use! :dancer: